### PR TITLE
Support for non-Arduino clients and some extra functions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/hbprotocol"]
 	path = src/hbprotocol
-	url = https://github.com/alex-makarov/bipropellant-protocol.git
+	url = https://github.com/bipropellant/hbprotocol.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/hbprotocol"]
 	path = src/hbprotocol
-	url = https://github.com/bipropellant/hbprotocol.git
+	url = https://github.com/alex-makarov/bipropellant-protocol.git

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # bipropellant-hoverboard-api
 
 C++ Wrapper around the [bipropellant hoverboard UART protocol](https://github.com/bipropellant/bipropellant-protocol).
-An Arduino compatible branch is atumatically generated: master_arduino. (This branch removes the submodule dependency.)
+An Arduino compatible branch is automatically generated: master_arduino. (This branch removes the submodule dependency.)
 
 Feel free to write Pull Requests for added features and examples.
 
@@ -10,17 +10,13 @@ For now, only functions are implemented which were needed by the Author. Many mo
 See https://github.com/bipropellant/bipropellant-protocol/blob/fe96935cb2f550110ffaaa6d74852bedd79e25c7/protocol.c#L266-L307 for possible information which could be accessed via this protocol.
 
 ## Implemented Features
-* Setting Motor PWM
+* Setting Motor PWM, also separately for left and right motor
 * Reading Motor Speeds
+* Setting Motor speeds, separately for left and right motor
+* Setting PID control values
 * Reading electrical Parameters (Voltage, Current..)
 * Subscribe to automatic updates of values
 * Schedule recurring transmission of values
 * Register callback function when values are received
 
 See https://github.com/bipropellant/bipropellant-hoverboard-api/blob/master/src/HoverboardAPI.cpp for detailed information of implemented functions.
-
-## Additions by Alex Makarov
-More ROS-friendly setup:
-* Adapted for using on 64-bit ARM platform
-* Removed Arduino dependencies
-* Added methods to set speed and PID control

--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ See https://github.com/bipropellant/bipropellant-protocol/blob/fe96935cb2f550110
 * Register callback function when values are received
 
 See https://github.com/bipropellant/bipropellant-hoverboard-api/blob/master/src/HoverboardAPI.cpp for detailed information of implemented functions.
+
+## Additions by Alex Makarov
+More ROS-friendly setup:
+* Adapted for using on 64-bit ARM platform
+* Removed Arduino dependencies
+* Added methods to set speed and PID control

--- a/src/HoverboardAPI.cpp
+++ b/src/HoverboardAPI.cpp
@@ -262,9 +262,7 @@ void HoverboardAPI::sendDifferentialPWM(int16_t left_cmd, int16_t right_cmd, cha
   PROTOCOL_BYTES_WRITEVALS *writevals = (PROTOCOL_BYTES_WRITEVALS *) &(msg.bytes);
   PROTOCOL_PWM_DATA *writespeed = (PROTOCOL_PWM_DATA *) writevals->content;
 
-
   writevals->cmd  = PROTOCOL_CMD_WRITEVAL;  // Write value
-
   writevals->code = Codes::setPointPWM;
 
   writespeed->pwm[0] = left_cmd;
@@ -277,8 +275,12 @@ void HoverboardAPI::sendDifferentialPWM(int16_t left_cmd, int16_t right_cmd, cha
 /***************************************************************************
  * Sends PWM values and Limits to hoverboard
  ***************************************************************************/
-void HoverboardAPI::sendPWMData(int16_t pwm, int16_t steer, int speed_max_power, int speed_min_power, int speed_minimum_pwm, char som) {
-
+void HoverboardAPI::sendPWMData(int16_t pwm,
+				int16_t steer,
+				int speed_max_power,
+				int speed_min_power,
+				int speed_minimum_pwm,
+				char som) {
   // Compose new Message
   PROTOCOL_MSG2 msg = {
     .SOM = som,
@@ -288,9 +290,7 @@ void HoverboardAPI::sendPWMData(int16_t pwm, int16_t steer, int speed_max_power,
   PROTOCOL_BYTES_WRITEVALS *writevals = (PROTOCOL_BYTES_WRITEVALS *) &(msg.bytes);
   PROTOCOL_PWM_DATA *writespeed = (PROTOCOL_PWM_DATA *) writevals->content;
 
-
   writevals->cmd  = PROTOCOL_CMD_WRITEVAL;  // Write value
-
   writevals->code = Codes::setPointPWMData;
 
   writespeed->pwm[0] = pwm + steer;
@@ -298,7 +298,6 @@ void HoverboardAPI::sendPWMData(int16_t pwm, int16_t steer, int speed_max_power,
   writespeed->speed_max_power = speed_max_power;
   writespeed->speed_min_power = speed_min_power;
   writespeed->speed_minimum_pwm = speed_minimum_pwm;
-
 
   msg.len = sizeof(writevals->cmd) + sizeof(writevals->code) + sizeof(*writespeed);
   protocol_post(&s, &msg);
@@ -320,14 +319,12 @@ void HoverboardAPI::sendSpeedData(double left_speed, double right_speed, int16_t
   writevals->cmd  = PROTOCOL_CMD_WRITEVAL;  // Write value
   writevals->code = Codes::setSpeed;
 
-  //      int32_t wanted_speed_mm_per_sec[2];
   writespeed->wanted_speed_mm_per_sec[0] = left_speed * 1000;
   writespeed->wanted_speed_mm_per_sec[1] = right_speed * 1000;
   writespeed->speed_max_power = max_power;
   writespeed->speed_min_power = -max_power;
   writespeed->speed_minimum_speed = min_speed;
 
-  // Only send 2x4 bytes -- speed control plus 2x4 bytes for limits
   msg.len = sizeof(writevals->cmd) + sizeof(writevals->code) + 8 + 8 + 4;
   protocol_post(&s, &msg);
 }
@@ -344,8 +341,7 @@ void HoverboardAPI::sendPIDControl(int16_t Kp, int16_t Ki, int16_t Kd, int16_t s
   uint16_t *value = (uint16_t*)writevals->content;
 
   // Kp, Ki, Kd, Speed Incr
-  // Original values 20 10 0 20
-  // more or less ok: 50 20 10 30
+  // Original values [20 10 0 20]. Works better on my motors (A.M.): [50 20 10 30] 
   writevals->code = Codes::setSpeedKp;
   
   *value = Kp;

--- a/src/HoverboardAPI.cpp
+++ b/src/HoverboardAPI.cpp
@@ -22,10 +22,35 @@
  *
  ***************************************************************************/
 
+#ifdef ARDUINO
 extern "C" {
   extern void delay(uint32_t ms);
   extern unsigned long millis(void);
 }
+#else
+#include <unistd.h>
+#include <time.h>
+
+void delay(uint32_t ms) { 
+  usleep (ms*1000); 
+}
+
+static uint64_t ts_start = 0;
+
+unsigned long millis() { 
+  struct timespec ts;
+
+  if (ts_start == 0) {
+    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+    ts_start = (uint64_t)ts.tv_sec * (uint64_t)1000 + (uint64_t)(ts.tv_nsec / 1000000L) ;
+  }
+
+  clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+  uint64_t ts_now = (uint64_t)ts.tv_sec * (uint64_t)1000 + (uint64_t)(ts.tv_nsec / 1000000L) ;
+
+  return (uint32_t)(ts_now - ts_start);
+}
+#endif
 
 uint32_t tickWrapper(void) { return (uint32_t) millis(); }
 
@@ -91,26 +116,23 @@ int HoverboardAPI::updateParamVariable(Codes code, void *ptr, int len) {
 /***************************************************************************
  * Print Protocol Statistics. Remote Data has to be requested first.
  ***************************************************************************/
-void HoverboardAPI::printStats(Stream &port) {
-  char buffer [100];
-  extern PROTOCOLCOUNT ProtocolcountData;
+void HoverboardAPI::printStats() {
+//   char buffer [100];
+   extern PROTOCOLCOUNT ProtocolcountData;
 
-/*
-  snprintf ( buffer, 100, "ACK RX: %4li TX: %4li RXmissing: %4li TXretries: %4i    ", s.ack.counters.rx, s.ack.counters.tx, s.ack.counters.rxMissing, s.ack.counters.txRetries);
-  port.print(buffer);
-  snprintf ( buffer, 100, "NOACK RX: %4li TX: %4li RXmissing: %4li TXretries: %4i    ", s.noack.counters.rx, s.noack.counters.tx, s.noack.counters.rxMissing, s.noack.counters.txRetries);
-  port.print(buffer);
-  snprintf ( buffer, 100, "Received RX: %4li TX: %4li RXmissing: %4li TXretries: %4i    ",  ProtocolcountData.rx, ProtocolcountData.tx, ProtocolcountData.rxMissing, ProtocolcountData.txRetries);
-  port.print(buffer);
-*/
+// /*
+//   snprintf ( buffer, 100, "ACK RX: %4li TX: %4li RXmissing: %4li TXretries: %4i    ", s.ack.counters.rx, s.ack.counters.tx, s.ack.counters.rxMissing, s.ack.counters.txRetries);
+//   port.print(buffer);
+//   snprintf ( buffer, 100, "NOACK RX: %4li TX: %4li RXmissing: %4li TXretries: %4i    ", s.noack.counters.rx, s.noack.counters.tx, s.noack.counters.rxMissing, s.noack.counters.txRetries);
+//   port.print(buffer);
+//   snprintf ( buffer, 100, "Received RX: %4li TX: %4li RXmissing: %4li TXretries: %4i    ",  ProtocolcountData.rx, ProtocolcountData.tx, ProtocolcountData.rxMissing, ProtocolcountData.txRetries);
+//   port.print(buffer);
+// */
 
-  snprintf ( buffer, 100, "Local  RX: %4li TX: %4li RXmissing: %4li    ", s.ack.counters.rx + s.noack.counters.rx, s.ack.counters.tx + s.noack.counters.tx, s.ack.counters.rxMissing + s.noack.counters.rxMissing);
-  port.print(buffer);
-  snprintf ( buffer, 100, "Remote RX: %4li TX: %4li RXmissing: %4li    ",  ProtocolcountData.rx, ProtocolcountData.tx, ProtocolcountData.rxMissing);
-  port.print(buffer);
-  snprintf ( buffer, 100, "Missed Local->Remote %4li (%4li) Remote->Local %4li (%4li)", s.ack.counters.tx + s.noack.counters.tx - ProtocolcountData.rx, ProtocolcountData.rxMissing, ProtocolcountData.tx - s.ack.counters.rx - s.noack.counters.rx, s.ack.counters.rxMissing + s.noack.counters.rxMissing);
-  port.print(buffer);
-  port.println();
+  // printf ( "Local  RX: %4d TX: %4d RXmissing: %4d    ", s.ack.counters.rx + s.noack.counters.rx, s.ack.counters.tx + s.noack.counters.tx, s.ack.counters.rxMissing + s.noack.counters.rxMissing);
+  // printf ( "Remote RX: %4d TX: %4d RXmissing: %4d    ",  ProtocolcountData.rx, ProtocolcountData.tx, ProtocolcountData.rxMissing);
+  // printf ( "Missed Local->Remote %4d (%4d) Remote->Local %4d (%4d)", s.ack.counters.tx + s.noack.counters.tx - ProtocolcountData.rx, ProtocolcountData.rxMissing, ProtocolcountData.tx - s.ack.counters.rx - s.noack.counters.rx, s.ack.counters.rxMissing + s.noack.counters.rxMissing);
+  // printf("\n");
 }
 
 
@@ -209,7 +231,6 @@ void HoverboardAPI::scheduleRead(Codes code, int count, unsigned int period, cha
  * Sends PWM values to hoverboard
  ***************************************************************************/
 void HoverboardAPI::sendPWM(int16_t pwm, int16_t steer, char som) {
-
   // Compose new Message
   PROTOCOL_MSG2 msg = {
     .SOM = som,
@@ -226,6 +247,28 @@ void HoverboardAPI::sendPWM(int16_t pwm, int16_t steer, char som) {
 
   writespeed->pwm[0] = pwm + steer;
   writespeed->pwm[1] = pwm - steer;
+
+  msg.len = sizeof(writevals->cmd) + sizeof(writevals->code) + sizeof(writespeed->pwm);
+  protocol_post(&s, &msg);
+}
+
+void HoverboardAPI::sendDifferentialPWM(int16_t left_cmd, int16_t right_cmd, char som) {
+  // Compose new Message
+  PROTOCOL_MSG2 msg = {
+    .SOM = som,
+  };
+
+  // Prepare Message structure to write PWM values.
+  PROTOCOL_BYTES_WRITEVALS *writevals = (PROTOCOL_BYTES_WRITEVALS *) &(msg.bytes);
+  PROTOCOL_PWM_DATA *writespeed = (PROTOCOL_PWM_DATA *) writevals->content;
+
+
+  writevals->cmd  = PROTOCOL_CMD_WRITEVAL;  // Write value
+
+  writevals->code = Codes::setPointPWM;
+
+  writespeed->pwm[0] = left_cmd;
+  writespeed->pwm[1] = right_cmd;
 
   msg.len = sizeof(writevals->cmd) + sizeof(writevals->code) + sizeof(writespeed->pwm);
   protocol_post(&s, &msg);
@@ -258,6 +301,67 @@ void HoverboardAPI::sendPWMData(int16_t pwm, int16_t steer, int speed_max_power,
 
 
   msg.len = sizeof(writevals->cmd) + sizeof(writevals->code) + sizeof(*writespeed);
+  protocol_post(&s, &msg);
+}
+
+/***************************************************************************
+ * Sends speed control to hoverboard
+ ***************************************************************************/
+void HoverboardAPI::sendSpeedData(double left_speed, double right_speed, int16_t max_power, int16_t min_speed, char som) {
+  // Compose new Message
+  PROTOCOL_MSG2 msg = {
+    .SOM = som,
+  };
+
+  // Prepare Message structure to write PWM values.
+  PROTOCOL_BYTES_WRITEVALS *writevals = (PROTOCOL_BYTES_WRITEVALS *) &(msg.bytes);
+  PROTOCOL_SPEED_DATA *writespeed = (PROTOCOL_SPEED_DATA *) writevals->content;
+
+  writevals->cmd  = PROTOCOL_CMD_WRITEVAL;  // Write value
+  writevals->code = Codes::setSpeed;
+
+  //      int32_t wanted_speed_mm_per_sec[2];
+  writespeed->wanted_speed_mm_per_sec[0] = left_speed * 1000;
+  writespeed->wanted_speed_mm_per_sec[1] = right_speed * 1000;
+  writespeed->speed_max_power = max_power;
+  writespeed->speed_min_power = -max_power;
+  writespeed->speed_minimum_speed = min_speed;
+
+  // Only send 2x4 bytes -- speed control plus 2x4 bytes for limits
+  msg.len = sizeof(writevals->cmd) + sizeof(writevals->code) + 8 + 8 + 4;
+  protocol_post(&s, &msg);
+}
+
+void HoverboardAPI::sendPIDControl(int16_t Kp, int16_t Ki, int16_t Kd, int16_t speed_increment, char som) {
+  // Compose new Message
+  PROTOCOL_MSG2 msg = {
+    .SOM = som,
+  };
+
+  // Prepare Message structure to write PWM values.
+  PROTOCOL_BYTES_WRITEVALS *writevals = (PROTOCOL_BYTES_WRITEVALS *) &(msg.bytes);
+  writevals->cmd  = PROTOCOL_CMD_WRITEVAL;  // Write value
+  uint16_t *value = (uint16_t*)writevals->content;
+
+  // Kp, Ki, Kd, Speed Incr
+  // Original values 20 10 0 20
+  // more or less ok: 50 20 10 30
+  writevals->code = Codes::setSpeedKp;
+  
+  *value = Kp;
+  msg.len = sizeof(writevals->cmd) + sizeof(writevals->code) + 2;
+  protocol_post(&s, &msg);
+
+  writevals->code = Codes::setSpeedKi;
+  *value = Ki;
+  protocol_post(&s, &msg);
+
+  writevals->code = Codes::setSpeedKd;
+  *value = Kd;
+  protocol_post(&s, &msg);
+
+  writevals->code = Codes::setSpeedIncrLimit;
+  *value = speed_increment;
   protocol_post(&s, &msg);
 }
 
@@ -409,3 +513,12 @@ double HoverboardAPI::getSpeed0_kmh() {
 double HoverboardAPI::getSpeed1_kmh() {
   return   HallData[1].HallSpeed_mm_per_s * 3600.0 / 1000000.0;
 }
+
+double HoverboardAPI::getPosition0_mm() {
+  return   HallData[0].HallPosn_mm;
+}
+
+double HoverboardAPI::getPosition1_mm() {
+  return   HallData[1].HallPosn_mm;
+}
+

--- a/src/HoverboardAPI.h
+++ b/src/HoverboardAPI.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "hbprotocol/protocol.h"
-#include "Stream.h"
+//#include "Stream.h"
 
 class HoverboardAPI
 {
@@ -14,6 +14,7 @@ class HoverboardAPI
   protocolCountACK         = 0x23,
   protocolCountnoACK       = 0x23,
   sensHall                 = 0x02,
+  setSpeed                 = 0x03,
   sensElectrical           = 0x08,
   enableMotors             = 0x09,
   disablePoweroff          = 0x0A,
@@ -21,6 +22,10 @@ class HoverboardAPI
   setPointPWMData          = 0x0D,
   setPointPWM              = 0x0E,
   setBuzzer                = 0x21,
+  setSpeedKp               = 0x85,
+  setSpeedKi               = 0x86,
+  setSpeedKd               = 0x87,
+  setSpeedIncrLimit        = 0x88
 };
 
   //commonly used functions **************************************************************************
@@ -38,7 +43,11 @@ class HoverboardAPI
 
 
     void sendPWM(int16_t pwm, int16_t steer = 0, char som = PROTOCOL_SOM_NOACK);
+    void sendDifferentialPWM(int16_t left_cmd, int16_t right_cmd, char som = PROTOCOL_SOM_NOACK);
     void sendPWMData(int16_t pwm, int16_t steer = 0, int speed_max_power = 600, int speed_min_power = -600, int speed_minimum_pwm = 10, char som = PROTOCOL_SOM_ACK);
+    void sendSpeedData(double left_speed, double right_speed, int16_t max_power, int16_t min_speed, char som = PROTOCOL_SOM_NOACK);
+    void sendPIDControl(int16_t Kp, int16_t Ki, int16_t Kd, int16_t speed_increment, char som = PROTOCOL_SOM_NOACK);
+
     void sendEnable(uint8_t newEnable, char som = PROTOCOL_SOM_ACK);
     void sendBuzzer(uint8_t buzzerFreq = 4, uint8_t buzzerPattern = 0, uint16_t buzzerLen = 100, char som = PROTOCOL_SOM_NOACK);
     void sendCounterReset(char som = PROTOCOL_SOM_ACK);
@@ -55,8 +64,11 @@ class HoverboardAPI
     double getSpeed0_mms();
     double getSpeed1_mms();
 
+    double getPosition0_mm();
+    double getPosition1_mm();
+
     void resetCounters();
-    void printStats(Stream &Port);
+    void printStats();
 
 
     //available but not commonly used functions ********************************************************

--- a/src/HoverboardAPI.h
+++ b/src/HoverboardAPI.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "hbprotocol/protocol.h"
-//#include "Stream.h"
+#ifdef ARDUINO
+#include "Stream.h"
+#endif
 
 class HoverboardAPI
 {

--- a/src/protocolFunctions.c
+++ b/src/protocolFunctions.c
@@ -15,16 +15,25 @@ volatile PROTOCOL_ELECTRICAL_PARAMS electrical_measurements;
 
 
 ////////////////////////////////////////////////////////////////////////////////////////////
+// Variable & Functions for 0x03 speed data
+
+volatile PROTOCOL_SPEED_DATA SpeedData;
+
+
+////////////////////////////////////////////////////////////////////////////////////////////
 // initialize protocol and register functions
 int setup_protocol() {
 
     int errors = 0;
 
-        errors += setParamVariable( 0x08, UI_NONE, (void *)&electrical_measurements, sizeof(PROTOCOL_ELECTRICAL_PARAMS), PARAM_RW);
-        setParamHandler(0x08, NULL);
+    errors += setParamVariable( 0x08, UI_NONE, (void *)&electrical_measurements, sizeof(PROTOCOL_ELECTRICAL_PARAMS), PARAM_RW);
+    setParamHandler(0x08, NULL);
 
-        errors += setParamVariable( 0x02, UI_NONE, (void *)&HallData,                sizeof(HallData), PARAM_RW);
-        setParamHandler(0x02, NULL);
+    errors += setParamVariable( 0x02, UI_NONE, (void *)&HallData,                sizeof(HallData), PARAM_RW);
+    setParamHandler(0x02, NULL);
+
+    errors += setParamVariable( 0x03, UI_NONE, (void *)&SpeedData,                sizeof(SpeedData), PARAM_RW);
+    setParamHandler(0x03, NULL);
 
     return errors;
 

--- a/src/protocolFunctions.h
+++ b/src/protocolFunctions.h
@@ -15,6 +15,7 @@ extern int setup_protocol();
 
 extern volatile PROTOCOL_ELECTRICAL_PARAMS electrical_measurements;
 extern volatile PROTOCOL_HALL_DATA_STRUCT HallData[2];
+extern volatile PROTOCOL_SPEED_DATA SpeedData;
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Please note that it requires [this PR](https://github.com/bipropellant/bipropellant-protocol/pull/31) for the protocol to be merged, as it contains integer type fixes for 32/64-bit systems.

Other than that, this PR excludes Arduino dependencies and adds a few other ways to control the motor: differential PWM, differential Speed with limits and PID control.
