### PR TITLE
Fixed constructor

### DIFF
--- a/src/HoverboardAPI.cpp
+++ b/src/HoverboardAPI.cpp
@@ -68,7 +68,6 @@ uint32_t tickWrapper(void)
 HoverboardAPI::HoverboardAPI(int (*send_serial_data)( unsigned char *data, int len )) :
   HoverboardAPI()
 {
-  HoverboardAPI();
   setSendSerialData(send_serial_data);
 }
 

--- a/src/HoverboardAPI.cpp
+++ b/src/HoverboardAPI.cpp
@@ -33,6 +33,7 @@ extern "C"
 #else
 #include <unistd.h>
 #include <time.h>
+extern "C" {
 
 void delay(uint32_t ms) {
   usleep (ms*1000);
@@ -55,6 +56,8 @@ unsigned long millis()
 
   return (uint32_t)(ts_now - ts_start);
 }
+
+}
 #endif
 
 uint32_t tickWrapper(void)
@@ -62,7 +65,8 @@ uint32_t tickWrapper(void)
   return (uint32_t) millis();
 }
 
-HoverboardAPI::HoverboardAPI(int (*send_serial_data)( unsigned char *data, int len ))
+HoverboardAPI::HoverboardAPI(int (*send_serial_data)( unsigned char *data, int len )) :
+  HoverboardAPI()
 {
   HoverboardAPI();
   setSendSerialData(send_serial_data);


### PR DESCRIPTION
Previous implementation led to construction of uninitialized object (read [here](https://hownot2code.com/2016/06/09/how-to-properly-call-one-constructor-from-another/) why). As a result, all message handlers for the protocol were NULL and no incoming messages were processed.
